### PR TITLE
Changed 'Pull From:' quay.io to 'Pull From:'

### DIFF
--- a/get_installer.sh.j2
+++ b/get_installer.sh.j2
@@ -1,4 +1,4 @@
 export PULL_SECRET="{{ pull_secret|default('openshift_pull.json') }}"
 OCP_REPO={{ 'ocp-dev-preview' if version == 'dev-preview' else 'ocp' }}
-export OPENSHIFT_RELEASE_IMAGE=$(curl -s {{ oc_release_img }}release.txt | grep 'Pull From: quay.io' | awk -F ' ' '{print $3}')
+export OPENSHIFT_RELEASE_IMAGE=$(curl -s {{ oc_release_img }}release.txt | grep 'Pull From' | awk -F ' ' '{print $3}')
 ./oc adm release extract --registry-config $PULL_SECRET --command=openshift-install --to . $OPENSHIFT_RELEASE_IMAGE


### PR DESCRIPTION
This commit was done because we cant relay on that the remote repository will always will be quay.io, As we can see with the following 4.14 version: https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.14.0-ec.4/release.txt